### PR TITLE
Document format of servername used for imap

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ At your option, this app will keep your mailing list memberships up-to-date on a
 
 This app requires the PHP `imap` module and a dedicated IMAP mailbox to function!
 
+To configure the IMAP server, use the format described in the php manual for [imap_open](https://www.php.net/manual/en/function.imap-open.php). For example to use a secure IMAP server attach `/ssl` to the servername: `imap.example.com/ssl`.
+
 ## Building the app
 Using NodeJS & NPM:
 ```


### PR DESCRIPTION
I had a hard time figuring out that one has to use the format from [imap_open](https://www.php.net/manual/en/function.imap-open.php) to configure the IMAP server, because my server only understands SSL on port 993 and since this produced only a timeout and not a helpful error message, the bug hunting was a bit annoying.